### PR TITLE
[Feat]: Add data convert tools

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,31 @@
+name: Pre-commit (changed files only)
+
+on:
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Get changed files
+        id: changed
+        run: |
+          files=$(git diff --name-only --diff-filter=ACMR \
+            origin/${{ github.base_ref }}...HEAD | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+
+      - name: Install pre-commit (pinned version)
+        run: pip install pre-commit==4.5.1
+
+      - name: Run pre-commit on changed files
+        if: steps.changed.outputs.files != ''
+        run: pre-commit run --files ${{ steps.changed.outputs.files }}

--- a/README.md
+++ b/README.md
@@ -216,7 +216,9 @@ Replace `libero_10_no_noops_lerobotv2.1` with the corresponding folder name of t
 <details>
 <summary><b>Private dataset directory structure</b></summary>
 
-If you train with fluxvla on private datasets, organize your data in the following format:
+If you train with fluxvla on private datasets, you need to convert your raw data (e.g., HDF5 files collected by ALOHA robots) into the LeRobot Dataset v2.1 format. For a step-by-step conversion guide, see [Data Conversion Guide](docs/data_convert.md).
+
+The converted dataset should follow this directory structure:
 
 ```
 ├── data

--- a/README_ja.md
+++ b/README_ja.md
@@ -216,7 +216,9 @@ huggingface-cli download limxdynamics/FluxVLAData --repo-type dataset --include 
 <details>
 <summary><b>プライベートデータセットのディレクトリ構造</b></summary>
 
-fluxvla をプライベートデータセットで学習する場合、次の形式でデータを整理してください：
+fluxvla をプライベートデータセットで学習する場合、まず生データ（例：ALOHA ロボットで収集した HDF5 ファイル）を LeRobot Dataset v2.1 形式に変換する必要があります。変換手順の詳細は [データ変換ガイド](docs/data_convert.md) をご覧ください。
+
+変換後のデータセットのディレクトリ構造は次のとおりです：
 
 ```
 ├── data

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -216,7 +216,9 @@ huggingface-cli download limxdynamics/FluxVLAData --repo-type dataset --include 
 <details>
 <summary><b>私有数据集目录结构</b></summary>
 
-若使用 fluxvla 在私有数据集上训练，请按以下格式组织数据：
+若使用 fluxvla 在私有数据集上训练，需要先将原始数据（如 ALOHA 双臂机器人采集的 HDF5 文件）转换为 LeRobot Dataset v2.1 格式。详细的转换步骤请参考 [数据转换指南](docs/data_convert.md)。
+
+转换后的数据集目录结构如下：
 
 ```
 ├── data

--- a/docs/data_convert.md
+++ b/docs/data_convert.md
@@ -1,0 +1,174 @@
+# DataConvert
+
+Data conversion tool: Convert HDF5 format data collected by the ALOHA dual-arm robot to the LeRobot Dataset v2.1 format.
+
+## Environment Setup
+
+1. Create a virtual environment
+
+   ```bash
+   conda create -y -n lerobot python=3.10
+   conda activate lerobot
+   conda install -c conda-forge ffmpeg av
+   ```
+
+2. Install lerobot
+
+   ```bash
+   cd tools
+   git clone https://github.com/huggingface/lerobot.git
+   cd lerobot
+   git checkout 55198de096f46a8e0447a8795129dd9ee84c088c
+   pip install -e .
+   ```
+
+______________________________________________________________________
+
+## Data Format Requirements
+
+> **Robot-type naming conventions** — field names and ordering vary by `--robot-type`:
+>
+> |                 | `aloha_sim`                         | `aloha`                                         |
+> | --------------- | ----------------------------------- | ----------------------------------------------- |
+> | **Joint order** | Left arm (7) + Right arm (7)        | Right arm (7) + Left arm (7)                    |
+> | **Cameras**     | `head_cam`, `left_cam`, `right_cam` | `cam_high`, `cam_left_wrist`, `cam_right_wrist` |
+
+### Input Data Format (HDF5)
+
+HDF5 files should follow the `episode_*.hdf5` naming convention. The conversion script recursively searches the specified directory for all matching files.
+
+#### Required Fields
+
+- **`/observations/qpos`** - Robot Joint Positions
+
+  - Data type: `float32` or `float64`
+  - Shape: `[num_frames, 14]` or `[num_frames, 16]` (16-dim is automatically converted to 14-dim)
+  - Notes:
+    - **16-dim format**: Gripper open/close is represented by the absolute positions of two gripper fingers (8 dims total)
+    - **14-dim format**: Gripper open/close is represented by a relative position normalized to \[0, 0.1\]
+    - Conversion formula: `gripper_value = (left_finger - right_finger) * (0.1 / 0.07)`
+
+- **`/observations/images/<camera_name>`** - Camera Images
+
+  - Format:
+    - Uncompressed 4D numpy array `[num_frames, height, width, channels]` (`uint8`)
+    - or JPEG-compressed byte stream `[num_frames]` (automatically decoded to RGB)
+
+#### Optional Fields
+
+- **`/action`** - Robot Desired Joint Positions
+
+  - Data type: `float32` or `float64`
+  - Shape: `[num_frames, 14]` or `[num_frames, 16]` (16-dim is automatically converted to 14-dim)
+
+- **`/observations/eepose`** - End-effector Pose
+
+  - Data type: `float32` or `float64`
+  - Shape: `[num_frames, 14]`
+  - Notes: Contains position (x, y, z) and quaternion (qx, qy, qz, qw) for both left and right end-effectors
+
+- **`/observations/images_depth/<camera_name>_depth`** - Depth images
+
+  - Data type: `uint16` (values in mm)
+  - Shape: `[num_frames, height, width]`
+  - Notes: Requires the `--depth` flag at runtime to be processed
+
+______________________________________________________________________
+
+### Output Data Format (LeRobot v2.1)
+
+The converted dataset follows the LeRobot v2.1 format, stored in a HuggingFace Datasets-compatible directory structure:
+
+```
+<output_dir>/<repo_id>/
+├── data/
+│   ├── train/
+│   │   ├── episode_0.parquet
+│   │   └── ...
+│   └── video/
+│       ├── episode_0/
+│       │   ├── observation.images.head_cam.mp4
+│       │   └── ...
+│       └── ...
+├── info.json
+└── meta.json
+```
+
+#### Data Field Descriptions
+
+Each episode's parquet file contains the following fields:
+
+- **`observation.state`**
+
+  - Description: Robot joint positions
+  - Type: `float32`
+  - Shape: `(14,)`
+
+- **`observation.images.<camera_name>`**
+
+  - Description: Camera reference containing the video file path and frame timestamp
+  - Type: `VideoFrame` object
+  - Video specs: MP4, 30 FPS, `(480, 640, 3)`
+
+- **`task`**
+
+  - Description: Task label; customizable via the `--init-task` parameter
+  - Type: `string`
+  - Default: `"pick up the yellow banana and put it on the pink plate"`
+
+- **`action`** (Optional)
+
+  - Description: Robot desired joint positions; only generated when the input contains `/action`
+  - Type: `float32`
+  - Shape: `(14,)`
+
+- **`observation.eepose`** (Optional)
+
+  - Description: End-effector pose; only generated when the input contains `/observations/eepose`
+  - Type: `float32`
+  - Shape: `(14,)`
+
+- **`observation.depth.<camera_name>`** (Optional)
+
+  - Description: Depth image; only generated when the input contains depth images and the `--depth` flag is specified
+  - Type: `uint16`
+  - Shape: `(480, 640)`
+
+______________________________________________________________________
+
+## Usage
+
+### Basic Usage
+
+```bash
+python convert_hdf_to_lerobot.py <raw_dir> [options]
+```
+
+**Arguments:**
+
+| Argument       | Type                  | Default           | Description                                                                                   |
+| -------------- | --------------------- | ----------------- | --------------------------------------------------------------------------------------------- |
+| `raw_dir`      | Positional (required) | —                 | Path to the directory containing HDF5 files to convert                                        |
+| `--repo-id`    | String                | `"0402"`          | Output dataset ID                                                                             |
+| `--output-dir` | Path                  | `HF_LEROBOT_HOME` | Output directory                                                                              |
+| `--init-task`  | String                | `None`            | Task description text, defaults to `"pick up the yellow banana and put it on the pink plate"` |
+| `--robot-type` | String                | `"aloha"`         | Robot type, options: `"aloha"` or `"aloha_sim"`                                               |
+| `--depth`      | Flag                  | `Off`             | Add this flag to convert depth images                                                         |
+
+**Auto-detection Notes:**
+
+- **`action`** and **`observation.eepose`** are automatically generated based on whether the HDF5 file contains `/action` and `/observations/eepose`, no manual configuration needed
+- **Depth images** must be explicitly enabled via the `--depth` flag
+
+______________________________________________________________________
+
+## Configuration Options
+
+Advanced conversion behavior can be adjusted by modifying the `DatasetConfig` class in the code:
+
+- `use_videos`: Whether to use video mode (default: `True`)
+- `direct_video_encoding`: Whether to use direct video encoding (default: `True`)
+- `direct_video_codec`: Video codec (default: `"libsvtav1"`)
+- `tolerance_s`: Timestamp tolerance (default: `0.0001`)
+- `image_writer_processes`: Number of image writer processes (default: `2`)
+- `image_writer_threads`: Number of threads per process (default: `6`)

--- a/tools/convert_hdf_to_lerobot.py
+++ b/tools/convert_hdf_to_lerobot.py
@@ -1,0 +1,75 @@
+"""
+Script to convert Aloha hdf5 data to the LeRobot dataset v2.1 format.
+"""
+
+import argparse
+from pathlib import Path
+
+from hdf_to_lerobot_pipeline import port_hdf5
+from lerobot.constants import HF_LEROBOT_HOME
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Convert Aloha HDF5 data to LeRobot dataset v2.1 format.',
+    )
+    parser.add_argument(
+        'raw_dir',
+        type=Path,
+        help='Path to the directory containing HDF5 files')
+    parser.add_argument(
+        '--repo-id',
+        type=str,
+        default='0402',
+        help='Dataset repository ID (default: 0402)',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=None,
+        help='Custom output directory (default: HF_LEROBOT_HOME)',
+    )
+    parser.add_argument(
+        '--init-task',
+        type=str,
+        default=None,
+        help='Default task description for frames without annotation',
+    )
+    parser.add_argument(
+        '--robot-type',
+        type=str,
+        default='aloha',
+        choices=['aloha', 'aloha_sim'],
+        help='Robot type (default: aloha)',
+    )
+    parser.add_argument(
+        '--depth',
+        action='store_true',
+        help='Include depth images in the conversion')
+
+    args = parser.parse_args()
+
+    print(f'HDF5 files directory: {args.raw_dir.absolute()}')
+    print(f'Output dataset ID: {args.repo_id}')
+    print(f'Robot type: {args.robot_type}')
+    if args.depth:
+        print('Depth conversion: enabled')
+    if args.output_dir:
+        print(f'Custom output directory: {args.output_dir.absolute()}')
+    else:
+        print(f'Using default output directory: {HF_LEROBOT_HOME.absolute()}')
+
+    port_hdf5(
+        raw_dir=args.raw_dir,
+        repo_id=args.repo_id,
+        robot_type=args.robot_type,
+        mode='video',
+        debug_mode=False,
+        output_dir=args.output_dir,
+        init_task=args.init_task,
+        convert_depth=args.depth,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/hdf_to_lerobot_direct_video.py
+++ b/tools/hdf_to_lerobot_direct_video.py
@@ -1,0 +1,343 @@
+from pathlib import Path
+from types import MethodType
+
+import numpy as np
+import PIL.Image
+import torch
+from lerobot.datasets.compute_stats import (compute_episode_stats,
+                                            get_feature_stats, sample_indices)
+from lerobot.datasets.image_writer import write_image
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.datasets.utils import (check_timestamps_sync,
+                                    get_episode_data_index,
+                                    hf_transform_to_torch,
+                                    validate_episode_buffer, validate_frame,
+                                    write_info)
+from lerobot.datasets.video_utils import decode_video_frames
+
+import datasets
+
+
+class DirectVideoWriter:
+    """Writes video frames directly via PyAV.
+
+    Bypasses the image-cache-then-encode pipeline.
+    """
+
+    def __init__(
+        self,
+        video_path: Path,
+        fps: int,
+        *,
+        vcodec: str = 'libsvtav1',
+        pix_fmt: str = 'yuv420p',
+        gop_size: int = 2,
+        crf: int = 30,
+    ):
+        self.video_path = Path(video_path)
+        self.video_path.parent.mkdir(parents=True, exist_ok=True)
+        self.fps = fps
+        self.vcodec = vcodec
+        self.pix_fmt = pix_fmt
+        self.gop_size = gop_size
+        self.crf = crf
+        self.container = None
+        self.stream = None
+
+    def _to_rgb_uint8(
+            self,
+            image: torch.Tensor | np.ndarray | PIL.Image.Image) -> np.ndarray:
+        if isinstance(image, torch.Tensor):
+            image = image.detach().cpu().numpy()
+        elif isinstance(image, PIL.Image.Image):
+            image = np.array(image.convert('RGB'))
+
+        if not isinstance(image, np.ndarray):
+            raise TypeError(
+                f'Unsupported image type for video encoding: {type(image)}')
+        if image.ndim != 3:
+            raise ValueError(
+                f'Expected image with 3 dimensions, got shape {image.shape}')
+
+        if image.shape[0] in (1, 3) and image.shape[-1] not in (1, 3):
+            image = np.transpose(image, (1, 2, 0))
+
+        if image.shape[-1] == 1:
+            image = np.repeat(image, 3, axis=-1)
+
+        if image.dtype.kind == 'f':
+            image = np.clip(image, 0.0, 1.0)
+            image = (image * 255).astype(np.uint8)
+        else:
+            image = np.clip(image, 0, 255).astype(np.uint8)
+
+        return np.ascontiguousarray(image)
+
+    def write(self,
+              image: torch.Tensor | np.ndarray | PIL.Image.Image) -> None:
+        image = self._to_rgb_uint8(image)
+        height, width = image.shape[:2]
+
+        if self.container is None:
+            import av
+
+            self.container = av.open(str(self.video_path), 'w')
+            self.stream = self.container.add_stream(
+                self.vcodec,
+                rate=self.fps,
+                options={
+                    'crf': str(self.crf),
+                    'g': str(self.gop_size)
+                },
+            )
+            self.stream.width = width
+            self.stream.height = height
+            self.stream.pix_fmt = self.pix_fmt
+
+        import av
+
+        frame = av.VideoFrame.from_ndarray(image, format='rgb24')
+        packet = self.stream.encode(frame)
+        if packet:
+            self.container.mux(packet)
+
+    def close(self) -> None:
+        if self.container is None:
+            return
+
+        packet = self.stream.encode()
+        if packet:
+            self.container.mux(packet)
+        self.container.close()
+        self.container = None
+        self.stream = None
+
+
+def enable_direct_video_patch(dataset: LeRobotDataset,
+                              codec: str = 'libsvtav1') -> LeRobotDataset:
+    """Monkey-patch *dataset* so that video frames are encoded on-the-fly
+    instead of first being cached as individual image files on disk."""
+
+    if len(dataset.meta.video_keys) == 0:
+        return dataset
+
+    dataset._direct_video_writers = {}
+    dataset._direct_video_codec = codec
+    dataset.batch_encoding_size = 1
+    dataset.episodes_since_last_encoding = 0
+
+    if dataset.image_writer is not None and len(dataset.meta.image_keys) == 0:
+        dataset.stop_image_writer()
+
+    def _get_direct_video_writer(self: LeRobotDataset, episode_index: int,
+                                 key: str) -> DirectVideoWriter:
+        writer_key = (episode_index, key)
+        if writer_key not in self._direct_video_writers:
+            video_path = self.root / self.meta.get_video_file_path(
+                episode_index, key)
+            self._direct_video_writers[writer_key] = DirectVideoWriter(
+                video_path=video_path,
+                fps=self.fps,
+                vcodec=self._direct_video_codec,
+            )
+        return self._direct_video_writers[writer_key]
+
+    def _close_episode_video_writers(self: LeRobotDataset,
+                                     episode_index: int) -> None:
+        for writer_key, writer in list(self._direct_video_writers.items()):
+            if writer_key[0] == episode_index:
+                writer.close()
+                del self._direct_video_writers[writer_key]
+
+    def _compute_direct_video_stats(
+        self: LeRobotDataset,
+        episode_index: int,
+        timestamps: list[float],
+    ) -> dict[str, dict[str, np.ndarray]]:
+        video_stats = {}
+        sampled_indices = sample_indices(len(timestamps))
+        sampled_timestamps = [
+            float(timestamps[idx]) for idx in sampled_indices
+        ]
+
+        for key in self.meta.video_keys:
+            video_path = self.root / self.meta.get_video_file_path(
+                episode_index, key)
+            frames = (
+                decode_video_frames(
+                    video_path,
+                    sampled_timestamps,
+                    self.tolerance_s,
+                    self.video_backend,
+                ).cpu().numpy())
+            stats = get_feature_stats(frames, axis=(0, 2, 3), keepdims=True)
+            video_stats[key] = {
+                k: v if k == 'count' else np.squeeze(v / 255.0, axis=0)
+                for k, v in stats.items()
+            }
+
+        return video_stats
+
+    def _patched_save_image(
+        self: LeRobotDataset,
+        image: torch.Tensor | np.ndarray | PIL.Image.Image,
+        fpath: Path,
+    ) -> None:
+        if self.image_writer is None:
+            if isinstance(image, torch.Tensor):
+                image = image.cpu().numpy()
+            write_image(image, fpath)
+        else:
+            self.image_writer.save_image(image=image, fpath=fpath)
+
+    def _patched_add_frame(
+        self: LeRobotDataset,
+        frame: dict,
+        task: str,
+        timestamp: float | None = None,
+    ) -> None:
+        for name in frame:
+            if isinstance(frame[name], torch.Tensor):
+                frame[name] = frame[name].numpy()
+
+        validate_frame(frame, self.features)
+
+        if self.episode_buffer is None:
+            self.episode_buffer = self.create_episode_buffer()
+
+        frame_index = self.episode_buffer['size']
+        if timestamp is None:
+            timestamp = frame_index / self.fps
+
+        self.episode_buffer['frame_index'].append(frame_index)
+        self.episode_buffer['timestamp'].append(timestamp)
+        self.episode_buffer['task'].append(task)
+
+        episode_index = self.episode_buffer['episode_index']
+
+        for key in frame:
+            if key not in self.features:
+                raise ValueError(f'An element of the frame is not in the '
+                                 f"features. '{key}' not in "
+                                 f"'{self.features.keys()}'.")
+
+            feature_dtype = self.features[key]['dtype']
+            if feature_dtype == 'image':
+                img_path = self._get_image_file_path(
+                    episode_index=episode_index,
+                    image_key=key,
+                    frame_index=frame_index,
+                )
+                if frame_index == 0:
+                    img_path.parent.mkdir(parents=True, exist_ok=True)
+                self._save_image(frame[key], img_path)
+                self.episode_buffer[key].append(str(img_path))
+            elif feature_dtype == 'video':
+                writer = self._get_direct_video_writer(episode_index, key)
+                writer.write(frame[key])
+                video_path = self.root / self.meta.get_video_file_path(
+                    episode_index, key)
+                self.episode_buffer[key].append(str(video_path))
+            else:
+                self.episode_buffer[key].append(frame[key])
+
+        self.episode_buffer['size'] += 1
+
+    def _patched_save_episode(self: LeRobotDataset,
+                              episode_data: dict | None = None) -> None:
+        episode_buffer = (
+            self.episode_buffer if episode_data is None else episode_data)
+        validate_episode_buffer(episode_buffer, self.meta.total_episodes,
+                                self.features)
+
+        episode_length = episode_buffer.pop('size')
+        tasks = episode_buffer.pop('task')
+        episode_tasks = list(set(tasks))
+        episode_index = episode_buffer['episode_index']
+
+        episode_buffer['index'] = np.arange(
+            self.meta.total_frames, self.meta.total_frames + episode_length)
+        episode_buffer['episode_index'] = np.full((episode_length, ),
+                                                  episode_index)
+
+        for episode_task in episode_tasks:
+            task_index = self.meta.get_task_index(episode_task)
+            if task_index is None:
+                self.meta.add_task(episode_task)
+
+        episode_buffer['task_index'] = np.array(
+            [self.meta.get_task_index(episode_task) for episode_task in tasks])
+
+        for key, ft in self.features.items():
+            if key in ['index', 'episode_index', 'task_index'
+                       ] or ft['dtype'] in [
+                           'image',
+                           'video',
+                       ]:
+                continue
+            episode_buffer[key] = np.stack(episode_buffer[key])
+
+        self._wait_image_writer()
+        self._close_episode_video_writers(episode_index)
+
+        if len(self.meta.video_keys) > 0 and episode_index == 0:
+            self.meta.update_video_info()
+            write_info(self.meta.info, self.meta.root)
+
+        episode_dict = {key: episode_buffer[key] for key in self.hf_features}
+        ep_dataset = datasets.Dataset.from_dict(
+            episode_dict, features=self.hf_features, split='train')
+        self.hf_dataset = datasets.concatenate_datasets(
+            [self.hf_dataset, ep_dataset])
+        self.hf_dataset.set_transform(hf_transform_to_torch)
+        ep_data_path = self.root / self.meta.get_data_file_path(
+            ep_index=episode_index)
+        ep_data_path.parent.mkdir(parents=True, exist_ok=True)
+        ep_dataset.to_parquet(ep_data_path)
+
+        non_video_data = {
+            key: value
+            for key, value in episode_buffer.items()
+            if key in self.features and self.features[key]['dtype'] != 'video'
+        }
+        episode_stats = compute_episode_stats(non_video_data, self.features)
+        episode_stats.update(
+            self._compute_direct_video_stats(episode_index,
+                                             episode_buffer['timestamp']))
+
+        self.meta.save_episode(episode_index, episode_length, episode_tasks,
+                               episode_stats)
+
+        ep_data_index = get_episode_data_index(self.meta.episodes,
+                                               [episode_index])
+        ep_data_index_np = {
+            key: value.numpy()
+            for key, value in ep_data_index.items()
+        }
+        check_timestamps_sync(
+            episode_buffer['timestamp'],
+            episode_buffer['episode_index'],
+            ep_data_index_np,
+            self.fps,
+            self.tolerance_s,
+        )
+
+        parquet_files = list(self.root.rglob('*.parquet'))
+        assert len(parquet_files) == self.num_episodes
+        video_files = list(self.root.rglob('*.mp4'))
+        assert len(video_files) == self.num_episodes * len(
+            self.meta.video_keys)
+
+        if episode_data is None:
+            self.episode_buffer = self.create_episode_buffer()
+
+    dataset._save_image = MethodType(_patched_save_image, dataset)
+    dataset._get_direct_video_writer = MethodType(_get_direct_video_writer,
+                                                  dataset)
+    dataset._close_episode_video_writers = MethodType(
+        _close_episode_video_writers, dataset)
+    dataset._compute_direct_video_stats = MethodType(
+        _compute_direct_video_stats, dataset)
+    dataset.add_frame = MethodType(_patched_add_frame, dataset)
+    dataset.save_episode = MethodType(_patched_save_episode, dataset)
+    return dataset

--- a/tools/hdf_to_lerobot_pipeline.py
+++ b/tools/hdf_to_lerobot_pipeline.py
@@ -1,0 +1,447 @@
+import dataclasses
+import gc
+import json
+import os
+import resource
+import shutil
+from dataclasses import field
+from pathlib import Path
+from typing import Literal
+
+import h5py
+import numpy as np
+import psutil
+import torch
+import tqdm
+from hdf_to_lerobot_direct_video import enable_direct_video_patch
+from lerobot.constants import HF_LEROBOT_HOME
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class DatasetConfig:
+    robot_type: str
+    use_videos: bool = True
+    direct_video_encoding: bool = True
+    direct_video_codec: str = 'libsvtav1'
+    tolerance_s: float = 0.0001
+    image_writer_processes: int = 2
+    image_writer_threads: int = 6
+    video_backend: str | None = None
+
+    camera_names: list[str] = field(init=False)
+    motors: list[str] = field(init=False)
+
+    _camera_names_dict: dict[str, list[str]] = field(
+        default_factory=lambda: {
+            'aloha_sim': ['head_cam', 'left_cam', 'right_cam'],
+            'aloha': ['cam_high', 'cam_left_wrist', 'cam_right_wrist'],
+        },
+        init=False,
+        repr=False,
+    )
+
+    _motors_dict: dict[str, list[str]] = field(
+        default_factory=lambda: {
+            'aloha_sim': [
+                'left_waist',
+                'left_shoulder',
+                'left_elbow',
+                'left_forearm_roll',
+                'left_wrist_angle',
+                'left_wrist_rotate',
+                'left_gripper',
+                'right_waist',
+                'right_shoulder',
+                'right_elbow',
+                'right_forearm_roll',
+                'right_wrist_angle',
+                'right_wrist_rotate',
+                'right_gripper',
+            ],
+            'aloha': [
+                'right_waist',
+                'right_shoulder',
+                'right_elbow',
+                'right_forearm_roll',
+                'right_wrist_angle',
+                'right_wrist_rotate',
+                'right_gripper',
+                'left_waist',
+                'left_shoulder',
+                'left_elbow',
+                'left_forearm_roll',
+                'left_wrist_angle',
+                'left_wrist_rotate',
+                'left_gripper',
+            ],
+        },
+        init=False,
+        repr=False,
+    )
+
+    add_infos: list = field(default_factory=list)
+
+    def __post_init__(self):
+        if (self.robot_type not in self._camera_names_dict
+                or self.robot_type not in self._motors_dict):
+            raise ValueError(f"Unsupported robot_type '{self.robot_type}'")
+        self.camera_names = self._camera_names_dict[self.robot_type]
+        self.motors = self._motors_dict[self.robot_type]
+
+
+# ---------------------------------------------------------------------------
+# HDF5 I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def has_cameras_depth(hdf5_files: list[Path]) -> bool:
+    with h5py.File(hdf5_files[0], 'r') as ep:
+        return '/observations/images_depth' in ep
+
+
+def has_eepose(hdf5_files: list[Path]) -> bool:
+    with h5py.File(hdf5_files[0], 'r') as ep:
+        return '/observations/eepose' in ep
+
+
+def has_action(hdf5_files: list[Path]) -> bool:
+    with h5py.File(hdf5_files[0], 'r') as ep:
+        return '/action' in ep
+
+
+def load_raw_images_per_camera(ep: h5py.File,
+                               cameras: list[str]) -> dict[str, np.ndarray]:
+    imgs_per_cam = {}
+    for camera in cameras:
+        uncompressed = ep[f'/observations/images/{camera}'].ndim == 4
+        if uncompressed:
+            imgs_array = ep[f'/observations/images/{camera}'][:]
+        else:
+            import cv2
+
+            imgs_array = []
+            for data in ep[f'/observations/images/{camera}']:
+                imgs_array.append(
+                    cv2.cvtColor(cv2.imdecode(data, 1), cv2.COLOR_BGR2RGB))
+            imgs_array = np.array(imgs_array)
+        imgs_per_cam[camera] = imgs_array
+    return imgs_per_cam
+
+
+def load_raw_images_depth_per_camera(
+        ep: h5py.File, cameras: list[str]) -> dict[str, np.ndarray]:
+    imgs_depth_per_cam = {}
+    for camera in cameras:
+        uncompressed = ep[
+            f'/observations/images_depth/{camera}_depth'].ndim == 3
+        if uncompressed:
+            imgs_array = ep[f'/observations/images_depth/{camera}_depth'][:]
+        else:
+            print('Skipping corrupted or invalid depth data.')
+            continue
+        imgs_depth_per_cam[camera] = imgs_array
+    return imgs_depth_per_cam
+
+
+def resize_dof_tensor(dof_tensor: torch.Tensor | None) -> torch.Tensor | None:
+    if dof_tensor is None or dof_tensor.shape[-1] != 16:
+        return dof_tensor
+    scale = 0.1 / 0.07
+    resized = torch.zeros(
+        *dof_tensor.shape[:-1],
+        14,
+        dtype=dof_tensor.dtype,
+        device=dof_tensor.device)
+    resized[..., 0:6] = dof_tensor[..., 0:6]
+    resized[..., 6] = (dof_tensor[..., 6] - dof_tensor[..., 7]) * scale
+    resized[..., 7:13] = dof_tensor[..., 8:14]
+    resized[..., 13] = (dof_tensor[..., 14] - dof_tensor[..., 15]) * scale
+    return resized
+
+
+def load_raw_episode_data(
+    ep_path: Path,
+    dataset_config: DatasetConfig,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray] | None, torch.Tensor,
+           torch.Tensor | None, torch.Tensor | None, ]:
+    with h5py.File(ep_path, 'r') as ep:
+        state = torch.from_numpy(ep['/observations/qpos'][:])
+        state = resize_dof_tensor(state)
+
+        action = None
+        if '/action' in ep:
+            action = torch.from_numpy(ep['/action'][:])
+            action = resize_dof_tensor(action)
+
+        eepose = None
+        if '/observations/eepose' in ep:
+            eepose = torch.from_numpy(ep['/observations/eepose'][:])
+
+        imgs_per_cam_depth = None
+        if ('/observations/images_depth' in ep
+                and 'depth' in dataset_config.add_infos):
+            try:
+                imgs_per_cam_depth = load_raw_images_depth_per_camera(
+                    ep, dataset_config.camera_names)
+            except Exception as e:
+                print(f'Error loading depth images: {e}')
+                imgs_per_cam_depth = None
+
+        imgs_per_cam = load_raw_images_per_camera(ep,
+                                                  dataset_config.camera_names)
+
+    return imgs_per_cam, imgs_per_cam_depth, state, action, eepose
+
+
+# ---------------------------------------------------------------------------
+# Dataset creation & conversion pipeline
+# ---------------------------------------------------------------------------
+
+
+def create_empty_dataset(
+    repo_id: str,
+    robot_type: str,
+    mode: Literal['video', 'image'] = 'video',
+    fps: int = 30,
+    *,
+    has_action: bool = False,
+    has_eepose: bool = False,
+    has_depth: bool = False,
+    dataset_config: DatasetConfig,
+    output_path: Path,
+) -> LeRobotDataset:
+    motors = dataset_config._motors_dict[robot_type]
+    cameras = dataset_config._camera_names_dict[robot_type]
+    features = {
+        'observation.state': {
+            'dtype': 'float32',
+            'shape': (len(motors), ),
+            'names': [motors],
+        },
+    }
+    if has_action:
+        features['action'] = {
+            'dtype': 'float32',
+            'shape': (len(motors), ),
+            'names': [motors],
+        }
+    if has_eepose:
+        features['observation.eepose'] = {
+            'dtype':
+            'float32',
+            'shape': (14, ),
+            'names': [
+                'left_x',
+                'left_y',
+                'left_z',
+                'left_qx',
+                'left_qy',
+                'left_qz',
+                'left_qw',
+                'right_x',
+                'right_y',
+                'right_z',
+                'right_qx',
+                'right_qy',
+                'right_qz',
+                'right_qw',
+            ],
+        }
+    if has_depth and 'depth' in dataset_config.add_infos:
+        for cam in cameras:
+            features[f'observation.depth.{cam}'] = {
+                'dtype': 'uint16',
+                'shape': (480, 640),
+                'names': ['height', 'width'],
+            }
+    for cam in cameras:
+        features[f'observation.images.{cam}'] = {
+            'dtype': mode,
+            'shape': (480, 640, 3),
+            'names': ['height', 'width', 'channels'],
+        }
+
+    if output_path.exists():
+        shutil.rmtree(output_path)
+
+    return LeRobotDataset.create(
+        repo_id=repo_id,
+        fps=fps,
+        robot_type=robot_type,
+        features=features,
+        root=output_path,
+        use_videos=dataset_config.use_videos,
+        tolerance_s=dataset_config.tolerance_s,
+        image_writer_processes=dataset_config.image_writer_processes,
+        image_writer_threads=dataset_config.image_writer_threads,
+        video_backend=dataset_config.video_backend,
+    )
+
+
+def load_task_annotations(task_path: Path | None,
+                          init_task: list[str]) -> list[str]:
+    if task_path is None:
+        print('No task file path provided, using default task list')
+        return init_task
+
+    if not task_path.exists():
+        raise FileNotFoundError(f'Task file {task_path} does not exist.')
+
+    with open(task_path, 'r') as f:
+        annotation = json.load(f)
+
+    for segment in annotation[0]:
+        if segment['label'] != 'empty':
+            start_frame = segment['start_frame']
+            end_frame = segment['end_frame']
+            init_task[start_frame:end_frame] = [segment['label']] * (
+                end_frame - start_frame)
+
+    return init_task
+
+
+def is_in_last_chunk(index: int, array_length: int, batch_size: int) -> bool:
+    total_chunks = (array_length + batch_size - 1) // batch_size
+    last_chunk_start = (total_chunks - 1) * batch_size
+    last_chunk_end = min(last_chunk_start + batch_size, array_length)
+    return last_chunk_start <= index < last_chunk_end
+
+
+def oom_finder() -> None:
+    process = psutil.Process(os.getpid())
+    mem = process.memory_info()
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print(f'************, RSS={mem.rss / 1024**2:.1f} MB, '  # noqa: E231
+          f'VMS={mem.vms / 1024**2:.1f} MB, '  # noqa: E231
+          f'peakRSS={peak / 1024:.1f} MB')  # noqa: E231
+
+
+def populate_dataset(
+    dataset: LeRobotDataset,
+    hdf5_files: list[Path],
+    task: list[Path | None],
+    episodes: list[int] | None = None,
+    dataset_config: DatasetConfig | None = None,
+    init_task: str | None = None,
+) -> LeRobotDataset:
+    if episodes is None:
+        episodes = range(len(hdf5_files))
+
+    for ep_idx in tqdm.tqdm(episodes):
+        oom_finder()
+
+        last_chunk_flag = is_in_last_chunk(ep_idx, len(hdf5_files),
+                                           dataset.batch_encoding_size)
+        if last_chunk_flag:
+            dataset.batch_encoding_size = 1
+
+        ep_path = hdf5_files[ep_idx]
+        task_path = task[ep_idx]
+
+        (imgs_per_cam, imgs_per_cam_depth, state, action,
+         eepose) = load_raw_episode_data(ep_path, dataset_config)
+
+        default_task = (
+            init_task if init_task is not None else
+            'pick up the yellow banana and put it on the pink plate')
+        init_task_list = [default_task for _ in range(len(state))]
+        tasks = load_task_annotations(task_path, init_task_list)
+        if all(task_name == 'empty' for task_name in tasks):
+            del imgs_per_cam, imgs_per_cam_depth, state, action, eepose
+            gc.collect()
+            continue
+
+        num_frames = state.shape[0]
+        for i in range(num_frames):
+            frame = {
+                'observation.state': state[i].float().numpy(),
+            }
+            for camera, img_array in imgs_per_cam.items():
+                frame[f'observation.images.{camera}'] = img_array[i]
+            if imgs_per_cam_depth is not None:
+                for camera, img_depth_array in imgs_per_cam_depth.items():
+                    frame[f'observation.depth.{camera}'] = img_depth_array[i]
+            if action is not None:
+                frame['action'] = action[i].float().numpy()
+            if eepose is not None:
+                frame['observation.eepose'] = eepose[i].float().numpy()
+            dataset.add_frame(frame, tasks[i])
+
+        dataset.save_episode()
+        del imgs_per_cam, imgs_per_cam_depth, state, action, eepose
+        gc.collect()
+
+        dataset.hf_dataset = dataset.create_hf_dataset()
+        gc.collect()
+
+    return dataset
+
+
+def collect_data_task(raw_dir: Path) -> tuple[list[Path], list[Path | None]]:
+    hdf5_files = sorted([f for f in raw_dir.rglob('episode_*.hdf5')])
+    task_files: list[Path | None] = [None] * len(hdf5_files)
+    return hdf5_files, task_files
+
+
+def port_hdf5(
+    raw_dir: Path,
+    repo_id: str,
+    *,
+    episodes: list[int] | None = None,
+    robot_type: Literal['aloha_sim', 'aloha'] = 'aloha_sim',
+    mode: Literal['video', 'image'] = 'video',
+    debug_mode: bool = False,
+    output_dir: Path | None = None,
+    init_task: str | None = None,
+    convert_depth: bool = False,
+):
+    if output_dir is None:
+        output_path = HF_LEROBOT_HOME / repo_id
+    else:
+        output_path = Path(output_dir) / repo_id
+
+    print(f'Dataset save path: {output_path.absolute()}')
+    print(f'Dataset ID: {repo_id}')
+
+    dataset_config = DatasetConfig(robot_type=robot_type)
+    if convert_depth:
+        dataset_config.add_infos.append('depth')
+    if not raw_dir.exists():
+        raise ValueError('raw_dir must be provided!')
+
+    hdf5_files, task_files = collect_data_task(raw_dir=raw_dir)
+
+    if debug_mode:
+        hdf5_files = hdf5_files[:1]
+
+    dataset = create_empty_dataset(
+        repo_id,
+        robot_type,
+        mode=mode,
+        has_eepose=has_eepose(hdf5_files),
+        has_depth=has_cameras_depth(hdf5_files),
+        has_action=has_action(hdf5_files),
+        dataset_config=dataset_config,
+        fps=30,
+        output_path=output_path,
+    )
+
+    if mode == 'video' and dataset_config.direct_video_encoding:
+        dataset = enable_direct_video_patch(
+            dataset, codec=dataset_config.direct_video_codec)
+
+    dataset = populate_dataset(
+        dataset,
+        hdf5_files,
+        task=task_files,
+        episodes=episodes,
+        dataset_config=dataset_config,
+        init_task=init_task,
+    )
+
+    return dataset


### PR DESCRIPTION
- Add HDF5-to-LeRobot data conversion tools for ALOHA robot datasets, supporting both direct video writing (PyAV) and pipeline-based encoding workflows
- Add data conversion documentation (docs/data_convert.md) with step-by-step guide for converting private datasets to LeRobot Dataset v2.1 format
- Update multilingual READMEs (EN/ZH/JA) with data conversion links and instructions