### PR TITLE
[Feat] Support training-time RTC for PI0.5

### DIFF
--- a/docs/rtc.md
+++ b/docs/rtc.md
@@ -30,10 +30,11 @@ model = dict(
             enabled=True,
             max_delay=7,
             distribution='exponential',  # 'exponential' (recommended) or 'uniform'
+            temperature=1.0,  # only used for 'exponential'; larger = flatter
         )))
 ```
 
-**PI0 (PI0FlowMatching)** — add directly under `model`:
+**PI0 / PI0.5 (PI0FlowMatching / PI05FlowMatching)** — add directly under `model`:
 
 ```python
 model = dict(
@@ -42,12 +43,17 @@ model = dict(
         enabled=True,
         max_delay=7,
         distribution='exponential',  # 'exponential' (recommended) or 'uniform'
+        temperature=1.0,  # only used for 'exponential'; larger = flatter
     ))
 ```
 
-> **Note**: PI0.5 (`PI05FlowMatching`) does not support training-time RTC.
-
 Mechanism: for each batch element, sample a delay `d ∈ [0, max_delay)`. The first `d` action steps are set to clean time (known no-noise states) and masked out from the loss.
+
+Delay distribution notes:
+
+- `distribution='uniform'`: all delays in `[0, max_delay)` are equally likely.
+- `distribution='exponential'`: favors small delays.
+- `temperature` only affects `distribution='exponential'`; `temperature=1.0` matches the original RTC behavior. Higher `temperature` increases coverage of larger delays and moves the distribution toward uniform, e.g. `max_delay=13, temperature=3`.
 
 #### Inference-side configuration
 
@@ -79,6 +85,7 @@ model = dict(
             enabled=True,
             max_delay=7,
             distribution='exponential',
+            temperature=1.0,
         )))
 
 # Optional continued finetuning from a pretrained checkpoint
@@ -151,19 +158,11 @@ Using GT as the prefix source keeps the prefix condition controlled and makes di
 Example commands:
 
 ```bash
-# GR00T / PI0 — run all modes (default)
 python scripts/test_rtc.py \
     --config configs/gr00t/gr00t_eagle_3b_aloha_full_finetune.py \
     --checkpoint /path/to/checkpoint.pt \
     --prefix_len 5 \
     --output_dir work_dirs/rtc_test
-
-# PI0.5 — skip prefix mode (unsupported)
-python scripts/test_rtc.py \
-    --config configs/pi05/pi05_paligemma_aloha_full_finetune.py \
-    --checkpoint /path/to/checkpoint.pt \
-    --prefix_len 5 \
-    --modes no_rtc guidance guidance_vjp
 ```
 
 ## Test visualization
@@ -190,7 +189,4 @@ This figure is intended as a qualitative reference for comparing post-prefix tra
 | ------------------------ | ----------------- | ------------- |
 | FlowMatchingHead (GR00T) | ✅                | ✅            |
 | PI0FlowMatching (PI0)    | ✅                | ✅            |
-| PI05FlowMatching (PI0.5) | ❌                | ✅            |
-
-> **Note**: PI0.5 does not support training-time RTC — its architecture
-> cannot inject per-position timesteps without model modifications.
+| PI05FlowMatching (PI0.5) | ✅                | ✅            |

--- a/fluxvla/engines/utils/rtc_training.py
+++ b/fluxvla/engines/utils/rtc_training.py
@@ -28,6 +28,7 @@ import torch
 def sample_training_delay(batch_size,
                           max_delay,
                           distribution='exponential',
+                          temperature=1.0,
                           device='cpu'):
     """Sample per-batch delay values for training-time RTC.
 
@@ -35,6 +36,9 @@ def sample_training_delay(batch_size,
         batch_size: Number of samples in the batch.
         max_delay: Maximum delay value (exclusive).
         distribution: 'exponential' (favors small delays) or 'uniform'.
+        temperature: Exponential temperature. Only used when
+            distribution='exponential'. 1.0 matches the current behavior;
+            larger values flatten toward uniform.
         device: Torch device.
 
     Returns:
@@ -44,11 +48,14 @@ def sample_training_delay(batch_size,
     if max_delay <= 0:
         return torch.zeros(batch_size, dtype=torch.long, device=device)
 
+    if temperature <= 0:
+        raise ValueError(f'Invalid temperature: {temperature}. Expected > 0.')
+
     if distribution == 'exponential':
         # Reference: PI Kinetix w = exp(arange(max_delay)[::-1])
         weights = torch.exp(
-            torch.arange(max_delay, dtype=torch.float32,
-                         device=device).flip(0))
+            torch.arange(max_delay, dtype=torch.float32, device=device).flip(0)
+            / temperature)
         weights = weights / weights.sum()
         delays = torch.multinomial(
             weights.expand(batch_size, -1), num_samples=1).squeeze(-1)

--- a/fluxvla/models/backbones/llms/condition_gemma.py
+++ b/fluxvla/models/backbones/llms/condition_gemma.py
@@ -123,9 +123,9 @@ class GemmaRMSNorm(nn.Module):
 
         # self.dense.to(dtype=torch.bfloat16).to(dtype=torch.float32)
         modulation = self.dense(cond)
-        # Reshape modulation to broadcast properly:
-        # [batch, 1, features] for [batch, seq, features]
-        if len(x.shape) == 3:  # [batch, seq, features]
+        # [batch, 1, features] for scalar cond;
+        # per-position [batch, seq, features] needs no reshape.
+        if modulation.dim() == 2 and len(x.shape) == 3:
             modulation = modulation.unsqueeze(1)
 
         scale, shift, gate = torch.chunk(modulation, 3, dim=-1)
@@ -1097,8 +1097,10 @@ class GemmaForCausalLM(GemmaPreTrainedModel, GenerationMixin):
             ignored (masked), the loss is only computed for the tokens with
             labels in `[0, ..., config.vocab_size]`.
 
-        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)`,
-            *optional*): Condition for ADARMS.
+        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)` or
+            `(batch_size, sequence_length, cond_dim)`, *optional*):
+            Condition for ADARMS. A batch-level condition is broadcast across
+            the sequence; a per-position condition is applied token-wise.
 
         Example:
 
@@ -1229,8 +1231,10 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
             (Mean-Square loss), If `config.num_labels > 1` a classification
             loss is computed (Cross-Entropy).
 
-        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)`,
-            *optional*): Condition for ADARMS.
+        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)` or
+            `(batch_size, sequence_length, cond_dim)`, *optional*):
+            Condition for ADARMS. A batch-level condition is broadcast across
+            the sequence; a per-position condition is applied token-wise.
         """
 
         transformer_outputs: BaseModelOutputWithPast = self.model(
@@ -1349,8 +1353,10 @@ class GemmaForTokenClassification(GemmaPreTrainedModel):
             (Mean-Square loss), If `config.num_labels > 1` a classification
             loss is computed (Cross-Entropy).
 
-        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)`,
-            *optional*): Condition for ADARMS.
+        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)` or
+            `(batch_size, sequence_length, cond_dim)`, *optional*):
+            Condition for ADARMS. A batch-level condition is broadcast across
+            the sequence; a per-position condition is applied token-wise.
         """
 
         outputs: BaseModelOutputWithPast = self.model(

--- a/fluxvla/models/heads/flow_matching_head.py
+++ b/fluxvla/models/heads/flow_matching_head.py
@@ -299,6 +299,7 @@ class FlowMatchingHead(nn.Module):
                 max_delay=self.rtc_training_config.get('max_delay', 5),
                 distribution=self.rtc_training_config.get(
                     'distribution', 'exponential'),
+                temperature=self.rtc_training_config.get('temperature', 1.0),
                 device=actions.device)
             t, action_masks = apply_rtc_time_conditioning(
                 t_scalar, action_masks, delays, T)  # (B, T)

--- a/fluxvla/models/vlas/pi05_flowmatching.py
+++ b/fluxvla/models/vlas/pi05_flowmatching.py
@@ -61,35 +61,9 @@ class PI05FlowMatching(PI0FlowMatching):
     """
 
     def __init__(self, **kwargs):
-        rtc_cfg = kwargs.get('rtc_training_config')
-        if rtc_cfg and rtc_cfg.get('enabled', False):
-            raise ValueError(
-                'PI05FlowMatching does not support training-time RTC. '
-                'Its architecture cannot inject per-position timesteps '
-                'without model modifications. Please disable '
-                'rtc_training_config or use test-time RTC (guidance) '
-                'instead.')
+        assert kwargs.get('state_proj') is None, (
+            'PI05FlowMatching does not use state_proj.')
         super().__init__(**kwargs)
-
-    def predict_action(self,
-                       *args,
-                       rtc_config=None,
-                       prev_actions=None,
-                       prefix_len=0,
-                       **kwargs):
-        if (prev_actions is not None and prefix_len > 0 and rtc_config
-                and rtc_config.get('method', 'prefix') == 'prefix'):
-            raise ValueError(
-                'PI05FlowMatching does not support RTC prefix mode at '
-                'inference. Its embed_suffix only accepts a scalar timestep '
-                'and cannot handle per-position time injection. '
-                "Use method='guidance' for test-time RTC instead.")
-        return super().predict_action(
-            *args,
-            rtc_config=rtc_config,
-            prev_actions=prev_actions,
-            prefix_len=prefix_len,
-            **kwargs)
 
     def embed_suffix(self, states, noisy_actions, timestep):
         """Embed the suffix tokens for the Pi0 head.
@@ -98,30 +72,25 @@ class PI05FlowMatching(PI0FlowMatching):
             state (torch.Tensor): The state tensor of shape (bsize, state_dim).
             noisy_actions (torch.Tensor): The noisy actions tensor of shape
                 (bsize, n_action_steps, action_dim).
-            timestep (torch.Tensor): The timestep tensor of shape (bsize,).
+            timestep (torch.Tensor): The timestep tensor of shape (bsize,)
+                for scalar time, or (bsize, n_action_steps) for per-position
+                time (used in training-time RTC).
 
         Returns:
-            Tuple[torch.Tensor, torch.Tensor, torch.Tensor]: A tuple
-                containing the embedded suffix tokens, padding masks,
-                and attention masks.
+            Tuple[torch.Tensor, torch.Tensor, torch.Tensor,
+                  torch.Tensor]: A tuple containing the embedded suffix
+                tokens, padding masks, attention masks, and adarms_cond.
         """
         embs = []
         pad_masks = []
         att_masks = []
 
-        # Embed state
         bsize = states.shape[0]
         dtype = states.dtype
         device = states.device
-        if self.state_proj is not None:
-            state_emb = self.state_proj(states)
-            embs.append(state_emb[:, None, :])
-            pad_masks.append(
-                torch.ones(bsize, 1, dtype=torch.bool, device=device))
-            att_masks += [1]
 
         # Set attention masks so that image and language
-        # inputs do not attend to state or actions
+        # inputs do not attend to action tokens
 
         # Embed timestep using sine-cosine positional
         # encoding with sensitivity in the range [0, 1]
@@ -145,7 +114,7 @@ class PI05FlowMatching(PI0FlowMatching):
             bsize, action_time_dim, dtype=torch.bool, device=device)
         pad_masks.append(action_time_mask)
 
-        # Set attention masks so that image, language and state
+        # Set attention masks so that image and language
         # inputs do not attend to action tokens
         att_masks += [1] + ([0] * (self.n_action_steps - 1))
 

--- a/fluxvla/models/vlas/pi0_flowmatching.py
+++ b/fluxvla/models/vlas/pi0_flowmatching.py
@@ -572,8 +572,7 @@ class PI0FlowMatching(BaseVLA):
         # Below we derive `t` which is passed to embed_suffix as the timestep:
         #   - RTC:     t is (B, T), per-position time (delay positions get
         #              0.0, meaning clean in PI0 convention).
-        #   - vanilla: t keeps (B,), same time for all positions. Must stay
-        #              1-D because PI05 embed_suffix only accepts (B,).
+        #   - vanilla: t keeps (B,), same time for all positions.
         T = actions.shape[1]
         if (self.rtc_training_config
                 and self.rtc_training_config.get('enabled', False)):
@@ -584,6 +583,7 @@ class PI0FlowMatching(BaseVLA):
                 max_delay=self.rtc_training_config.get('max_delay', 5),
                 distribution=self.rtc_training_config.get(
                     'distribution', 'exponential'),
+                temperature=self.rtc_training_config.get('temperature', 1.0),
                 device=actions.device)
             t, action_masks = apply_rtc_time_conditioning(
                 time, action_masks, delays, T, clean_time=0.0)  # (B, T)

--- a/scripts/test_rtc.py
+++ b/scripts/test_rtc.py
@@ -24,13 +24,6 @@ Usage:
         --checkpoint /path/to/checkpoint.pt \
         --prefix_len 5 \
         --output_dir work_dirs/rtc_test
-
-    # PI0.5 — skip prefix (unsupported), run guidance only
-    python scripts/test_rtc.py \
-        --config configs/pi05/xxx.py \
-        --checkpoint /path/to/checkpoint.pt \
-        --prefix_len 5 \
-        --modes no_rtc guidance guidance_vjp
 """
 
 import argparse
@@ -329,9 +322,7 @@ def main():
     selected RTC modes, and generates per-dimension denoising
     visualizations.
 
-    Use ``--modes`` to choose which modes to run.  Defaults to all
-    four modes; pass a subset for models that do not support certain
-    modes (e.g. PI0.5 does not support ``prefix``).
+    Use ``--modes`` to choose which modes to run.
     """
     parser = argparse.ArgumentParser(description='End-to-end RTC test')
     parser.add_argument(


### PR DESCRIPTION
PI0.5 previously blocked training-time RTC because its conditioning path assumed a scalar timestep.

This PR enables training-time RTC in PI0.5 and makes RTC delay sampling more configurable. Specifically, it:

- updates GemmaRMSNorm to accept per-position adarms_cond
- removes the PI05FlowMatching restrictions that previously disabled RTC
- keeps state_proj config compatibility in PI0.5 while ignoring it, since PI0.5 does not use state embeddings
- adds a configurable temperature for exponential RTC delay sampling, allowing better coverage of larger delays without switching to uniform sampling

Test results:
<img width="600" height="250" alt="7514345f-ccf1-4dac-8da8-881dfbf5bede" src="https://github.com/user-attachments/assets/0ef8a25a-c35e-4874-ac21-1215d7d2d8cf" />

<img width="2100" height="7200" alt="e476235c-6e0e-41b1-87a4-b21204027198" src="https://github.com/user-attachments/assets/f0d96679-d9f2-4125-a725-0a15a210a916" />
