### PR TITLE
[Chore] Add AI coding assistant files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,18 @@ datasets/*
 
 # Ignore local experiment directories
 src/
+
+# Coding assistants' stuff
+.agents/
+/CLAUDE.md
+/instructions.md
+.claude/
+/GEMINI.md
+.gemini/
+AGENTS.md
+.codex/
+
+# Cursor specific files
+.cursor
+.cursorignore
+.cursorindexingignore


### PR DESCRIPTION
Following LLVM's approach, ignore common AI coding assistant configuration files and directories (Claude, Gemini, Codex, Cursor) to avoid accidentally committing local developer-specific artifacts.

Refer to: https://github.com/llvm/llvm-project/blob/main/.gitignore