### PR TITLE
[Fix] Use DataLoader worker info to prevent duplicate data across wor…

### DIFF
--- a/fluxvla/datasets/dataset_wrapper.py
+++ b/fluxvla/datasets/dataset_wrapper.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Union
 
 import numpy as np
+import torch
 from torch.utils.data import IterableDataset
 
 from fluxvla.engines import (DATASETS, build_dataset_from_cfg,
@@ -458,16 +459,28 @@ class DistributedRepeatingDataset(IterableDataset):
         pass
 
     def __iter__(self):
+        # Incorporate DataLoader worker info so that data is split
+        # across both distributed processes AND per-process workers.
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            worker_id = worker_info.id
+            num_workers = worker_info.num_workers
+        else:
+            worker_id = 0
+            num_workers = 1
+
+        # Effective world: distributed processes × per-process workers
+        total_world = self.world_size * num_workers
+        total_rank = self.rank * num_workers + worker_id
+
         epoch = 0
         while True:
-            # Create indices for the entire virtual concatenated dataset
             indices = np.arange(self.total_len)
             if self.shuffle:
                 rng = np.random.default_rng(self.seed + epoch)
                 rng.shuffle(indices)
 
-            # Distribute the indices across the world size
-            shard = indices[self.rank::self.world_size].tolist()
+            shard = indices[total_rank::total_world].tolist()
 
             for idx in shard:
                 yield self._get_item_from_global_idx(idx)

--- a/fluxvla/datasets/dataset_wrapper.py
+++ b/fluxvla/datasets/dataset_wrapper.py
@@ -47,8 +47,9 @@ class DistributedRepeatingDataset(IterableDataset):
             to collect statistics.
         name_mappings (dict, optional): Mappings for
             statistic names. Defaults to None.
-        shuffle (bool): Whether to shuffle the dataset
-            at each epoch.
+        shuffle (bool): Whether to shuffle the dataset.
+        reshuffle_each_epoch (bool): Whether to change the shuffle order
+            after each full pass over the local shard. Defaults to False.
         seed (int): Seed for random number generation.
         statistic_name (str): Name for the statistics collection.
         dim (int, optional): Target dimension for padding/copying data.
@@ -61,11 +62,13 @@ class DistributedRepeatingDataset(IterableDataset):
                  statistic_keys: List[str],
                  name_mappings: Dict = None,
                  shuffle: bool = True,
+                 reshuffle_each_epoch: bool = False,
                  seed: int = 42,
                  statistic_name: str = 'private',
                  dim: Optional[int] = None,
                  dataset_statistics: Optional[Dict] = None) -> None:
         self.shuffle = shuffle
+        self.reshuffle_each_epoch = reshuffle_each_epoch
         self.seed = seed
         self.statistic_name = statistic_name
         self.dim = dim
@@ -179,6 +182,7 @@ class DistributedRepeatingDataset(IterableDataset):
         # Get the rank and world size from the overwatch
         self.rank = overwatch.rank()
         self.world_size = overwatch.world_size()
+        self._epoch = 0
 
     def _get_item_from_global_idx(self, global_idx):
         """Get item from global index, handling single, list,
@@ -473,11 +477,11 @@ class DistributedRepeatingDataset(IterableDataset):
         total_world = self.world_size * num_workers
         total_rank = self.rank * num_workers + worker_id
 
-        epoch = 0
         while True:
             indices = np.arange(self.total_len)
             if self.shuffle:
-                rng = np.random.default_rng(self.seed + epoch)
+                epoch_offset = self._epoch if self.reshuffle_each_epoch else 0
+                rng = np.random.default_rng(self.seed + epoch_offset)
                 rng.shuffle(indices)
 
             shard = indices[total_rank::total_world].tolist()
@@ -485,7 +489,8 @@ class DistributedRepeatingDataset(IterableDataset):
             for idx in shard:
                 yield self._get_item_from_global_idx(idx)
 
-            epoch += 1
+            if self.reshuffle_each_epoch:
+                self._epoch += 1
 
     def __len__(self):
         """Return the total length of all datasets."""


### PR DESCRIPTION
…kers

Reported-by: @yangyan010119

| Codebase                    | Libero-Spatial | Libero-Object | Libero-Goal | Libero-Long | Libero-Average |
| --------------------------- | :------------: | :-----------: | :---------: | :---------: | :------------: |
| GR00T Before              | 96.2          | 96.8          | 93.4          | 89.4±1.5      | 93.95          |
| GR00T After               | 97.4          | 96.2          | 94.6          | 93.0          | 95.3           |
| **Diff (Δ)**              | <strong>+1.2 ↑</strong> | <strong>-0.6 ↓</strong> | <strong>+1.2 ↑</strong> | <strong>+3.6 ↑</strong> | <strong>+1.4 ↑</strong> |
| Pi Before            |      98.6      |     99.0      |    97.8     |   96±1.0    |     97.85      |
| Pi After             |     98.6      |     99.6      |    98.0     |   95.6    |    97.95       |
| **Diff (Δ)**    | <strong>0.0</strong> | <strong>+0.6 ↑</strong> | <strong>+0.2 ↑</strong> | <strong>-0.4↓</strong> | <strong>+0.1↑</strong> |
| SmolVLA Before        |      87.4      |     93.2      |    92.0     |    63.4     |      84.0      |
| SmolVLA After          |      86.4      |     93.6      |    88.0     |    60.0     |      82.0      |
| **Diff (Δ)**    | <strong>-1.0 ↓</strong> | <strong>+0.4 ↑</strong> | <strong>-4.0 ↓</strong> | <strong>-3.4 ↓</strong> | <strong>-2.0 ↓</strong> |
