### PR TITLE
[Fix]: Fix logger repeated problem

### DIFF
--- a/fluxvla/engines/runners/base_train_runner.py
+++ b/fluxvla/engines/runners/base_train_runner.py
@@ -711,7 +711,7 @@ class BaseTrainRunner(ABC):
                     global_step=self.metric.global_step + 1,
                     epoch=self.current_epoch,
                     lr=self.lr_scheduler.get_last_lr()[0])
-                progress.set_description(self.metric.push())
+                progress.set_description(self.metric.push(), refresh=False)
                 progress.update()
 
                 # Save checkpoint


### PR DESCRIPTION
## Summary
This PR fixes duplicate/two-line progress output during training by disabling immediate tqdm refresh when updating the progress bar description.

## Changes
- Update `BaseTrainRunner` to call `progress.set_description(..., refresh=False)`.
- Keep the existing `progress.update()` flow unchanged, so tqdm refresh happens through the normal update path instead of forcing an extra redraw.