### PR TITLE
Fix redundant image resize during LIBERO eval

### DIFF
--- a/configs/gr00t/gr00t_qwenvl_3b_libero_10_full_finetune.py
+++ b/configs/gr00t/gr00t_qwenvl_3b_libero_10_full_finetune.py
@@ -204,6 +204,7 @@ eval = dict(
                 image_mean=[0.48145466, 0.4578275, 0.40821073],
                 image_std=[0.26862954, 0.26130258, 0.27577711],
                 img_key='pixel_values',
+                exact_resize_size=(224, 224),
                 to_tensor=True),
             dict(
                 type='LiberoPromptFromInputs',

--- a/configs/llava/llavavla_qwenvl_3b_libero_10_full_train.py
+++ b/configs/llava/llavavla_qwenvl_3b_libero_10_full_train.py
@@ -270,6 +270,7 @@ eval = dict(
                 image_mean=[0.48145466, 0.4578275, 0.40821073],
                 image_std=[0.26862954, 0.26130258, 0.27577711],
                 img_key='pixel_values',
+                exact_resize_size=(224, 224),
                 to_tensor=True),
             dict(
                 type='LiberoPromptFromInputs',

--- a/configs/smolvla/smolvla_libero_10_finetune.py
+++ b/configs/smolvla/smolvla_libero_10_finetune.py
@@ -191,7 +191,6 @@ eval = dict(
             dict(
                 type='ProcessLiberoEvalInputs',
                 img_keys=['agentview_image', 'robot0_eye_in_hand_image'],
-                resize_size=512,
             ),
             dict(
                 type='TransformImage',

--- a/configs/smolvla/smolvla_libero_goal_finetune.py
+++ b/configs/smolvla/smolvla_libero_goal_finetune.py
@@ -191,7 +191,6 @@ eval = dict(
             dict(
                 type='ProcessLiberoEvalInputs',
                 img_keys=['agentview_image', 'robot0_eye_in_hand_image'],
-                resize_size=512,
             ),
             dict(
                 type='TransformImage',

--- a/configs/smolvla/smolvla_libero_object_finetune.py
+++ b/configs/smolvla/smolvla_libero_object_finetune.py
@@ -191,7 +191,6 @@ eval = dict(
             dict(
                 type='ProcessLiberoEvalInputs',
                 img_keys=['agentview_image', 'robot0_eye_in_hand_image'],
-                resize_size=512,
             ),
             dict(
                 type='TransformImage',

--- a/configs/smolvla/smolvla_libero_spatial_finetune.py
+++ b/configs/smolvla/smolvla_libero_spatial_finetune.py
@@ -191,7 +191,6 @@ eval = dict(
             dict(
                 type='ProcessLiberoEvalInputs',
                 img_keys=['agentview_image', 'robot0_eye_in_hand_image'],
-                resize_size=512,
             ),
             dict(
                 type='TransformImage',

--- a/fluxvla/transforms/transform_images.py
+++ b/fluxvla/transforms/transform_images.py
@@ -901,6 +901,7 @@ class QWen2VLImageTransform:
         merge_size: int = 2,
         img_key: str = 'images',
         to_tensor: bool = False,
+        exact_resize_size: Optional[Tuple[int, int]] = None,
         **kwargs,
     ) -> None:
         self.img_transform = Qwen2VLImageProcessorHF(
@@ -921,11 +922,29 @@ class QWen2VLImageTransform:
             **kwargs)
         self.img_key = img_key
         self.to_tensor = to_tensor
+        self.exact_resize_size = exact_resize_size
+
+    def _exact_resize(self, images: np.ndarray) -> np.ndarray:
+        if self.exact_resize_size is None:
+            return images
+        if len(self.exact_resize_size) != 2:
+            raise ValueError(
+                'exact_resize_size must be a (height, width) pair.')
+        height, width = self.exact_resize_size
+        resized_images = []
+        for image in images:
+            resized_images.append(
+                cv2.resize(
+                    image.transpose(1, 2, 0), (width, height),
+                    interpolation=cv2.INTER_CUBIC).transpose(2, 0, 1))
+        return np.stack(resized_images, axis=0)
 
     def __call__(self, inputs):
-        ret_dict = self.img_transform(inputs[self.img_key].reshape(
-            -1, 3, inputs[self.img_key].shape[-2],
-            inputs[self.img_key].shape[-1]))
+        images = inputs[self.img_key].reshape(-1, 3,
+                                              inputs[self.img_key].shape[-2],
+                                              inputs[self.img_key].shape[-1])
+        images = self._exact_resize(images)
+        ret_dict = self.img_transform(images)
         if self.to_tensor:
             inputs[self.img_key] = torch.from_numpy(ret_dict['pixel_values'])
             inputs['image_grid_thw'] = torch.from_numpy(

--- a/fluxvla/transforms/transform_inputs.py
+++ b/fluxvla/transforms/transform_inputs.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import logging
 import os
 from pathlib import Path
@@ -26,7 +25,7 @@ import torchvision
 from PIL import Image
 
 from fluxvla.engines import TRANSFORMS
-from fluxvla.engines.utils.eval_utils import crop_and_resize, get_libero_image
+from fluxvla.engines.utils.eval_utils import crop_and_resize
 from .utils import pad_to_dim, parse_image
 
 
@@ -332,26 +331,26 @@ class ProcessOBSInputs():
 @TRANSFORMS.register_module()
 class ProcessLiberoEvalInputs:
     """ Process Libero eval inputs.
-    This class processes the Libero eval inputs by loading the images,
-    applying the center crop, and returning the processed inputs.
+    This transform loads LIBERO observation images, rotates them, converts
+    them to PIL images, and leaves model-specific resizing to later image
+    transforms. If enabled, center crop is applied with the same TensorFlow
+    crop-and-resize path used by the original OpenVLA evaluation.
 
     Args:
         img_keys (List[str]): Image keys to fetch from inputs.
             Default to ['agentview_image'].
-        center_crop (bool): If True, center crop at 0.9 area before resize.
-            Default to False.
+        center_crop (bool): If True, center crop to 0.9 area and resize back
+            to 224x224 before later model-specific processing.
         use_pil (bool): If True, use PIL to load the images.
             Default to True.
     """
 
     def __init__(self,
                  img_keys: List[str] = ['agentview_image'],
-                 resize_size: int = 224,
                  center_crop: bool = False,
                  use_pil: bool = True,
                  embodiment_id: int = None) -> None:
         self.img_keys = img_keys
-        self.resize_size = resize_size
         self.center_crop = center_crop
         self.use_pil = use_pil
         self.embodiment_id = embodiment_id
@@ -359,11 +358,15 @@ class ProcessLiberoEvalInputs:
     def __call__(self, inputs: Dict) -> Dict:
         # Load raw images
         imgs = list()
+        replay_img = None
         for img_key in self.img_keys:
             if img_key not in inputs:
                 raise KeyError(f'Image key `{img_key}` not found in inputs!')
-            imgs.append(get_libero_image(inputs, self.resize_size, img_key))
-        replay_img = copy.deepcopy(imgs[0])
+            img = np.asarray(inputs[img_key])
+            img = img[::-1, ::-1].copy()
+            if replay_img is None:
+                replay_img = img.copy()
+            imgs.append(img)
         images = list()
         img_masks = list()
         if self.use_pil:
@@ -371,35 +374,19 @@ class ProcessLiberoEvalInputs:
                 image = Image.fromarray(img)
                 image = image.convert('RGB')
 
-                # (If trained with image augmentations)
-                # Center crop image and then
-                # resize back up to original size.
-                # IMPORTANT: Let's say crop scale == 0.9. To get the new height
-                # and width (post-crop), multiply
-                # the original height and width by sqrt(0.9) -- not 0.9!
                 if self.center_crop:
                     batch_size = 1
                     crop_scale = 0.9
-
-                    # Convert to TF Tensor and record original data type
-                    # (should be tf.uint8)
                     image = tf.convert_to_tensor(np.array(image))
                     orig_dtype = image.dtype
-
-                    # Convert to data type tf.float32 and values between [0,1]
                     image = tf.image.convert_image_dtype(image, tf.float32)
-
-                    # Crop and then resize back to original size
                     image = crop_and_resize(image, crop_scale, batch_size)
-
-                    # Convert back to original data type
                     image = tf.clip_by_value(image, 0, 1)
                     image = tf.image.convert_image_dtype(
                         image, orig_dtype, saturate=True)
-
-                    # Convert back to PIL Image
                     image = Image.fromarray(image.numpy())
                     image = image.convert('RGB')
+
                 images.append(image)
                 img_masks.append(True)
         else:


### PR DESCRIPTION
  ## Removed

  - Removed `resize_size` from `ProcessLiberoEvalInputs`.
  - Removed the `get_libero_image(..., resize_size, ...)` path from eval input preprocessing.
  - Removed the TensorFlow `center_crop -> crop_and_resize` resize path inside `ProcessLiberoEvalInputs`.
  - Removed explicit `resize_size=512` from SmolVLA eval `ProcessLiberoEvalInputs` configs.

  ## Added

  - Added `exact_resize_size` to `QWen2VLImageTransform`.
  - Qwen eval configs now set `exact_resize_size=(224, 224)` so Qwen inputs are resized exactly once in the downstream image transform.
  - LIBERO eval input preprocessing now only loads raw images, applies the existing 180-degree rotation, converts to PIL images, and leaves model-specific resize to later transforms.

  ## Validation

  - Ran `pre-commit run --files` on all changed files.
  - Ran Python compile check for modified transform files.