### PR TITLE
[Fix]: Fix arm/sarm dataset

### DIFF
--- a/fluxvla/datasets/parquet_dataset_v3.py
+++ b/fluxvla/datasets/parquet_dataset_v3.py
@@ -196,6 +196,9 @@ class ParquetDatasetV3(ParquetDataset):
             datasets.append(hf_dataset)
         self.dataset_cumulative_sizes = np.cumsum([0] + dataset_sizes)
         self.dataset = concatenate_datasets(datasets)
+        self.full_length = len(self.dataset)
+        self.sample_indices = np.arange(self.full_length, dtype=np.int64)
+        self.effective_length = self.full_length
         self.transforms = list()
         self.action_key = action_key
         self.use_delta = use_delta

--- a/fluxvla/datasets/sarm_dataset.py
+++ b/fluxvla/datasets/sarm_dataset.py
@@ -307,6 +307,8 @@ class SARMDataset(ParquetDatasetV3):
 
         for transform in self.transforms:
             output = transform(output)
+        # Stats are only needed by NormalizeStatesAndActions.
+        output.pop('stats', None)
         return output
 
     def _get_state_statistics(self, dataset_idx: int,


### PR DESCRIPTION
## Summary

This PR fixes dataset runtime issues in the ARM/SARM training path.

- Initialize `ParquetDatasetV3` length and sampling metadata:
  - `full_length`
  - `sample_indices`
  - `effective_length`
- Remove the temporary `stats` field from `SARMDataset` outputs after transforms, since it is only needed by `NormalizeStatesAndActions`.
- Prevent `DictCollator` from failing with:
  `KeyError: "Key 'stats' is not in keys or meta_keys. Please specify its behavior."`

## Why

`SARMDataset` adds `stats` so state normalization transforms can use dataset statistics, but the field was still present when samples reached `DictCollator`. Since SARM configs do not declare `stats` as either a stacked key or a meta key, the DataLoader worker crashed during collation.

`ParquetDatasetV3` also now mirrors the expected dataset length/index metadata used by the base parquet dataset path.

## Testing

- Checked `fluxvla/datasets/sarm_dataset.py` diagnostics: no errors.
- Built the `configs/sarm/sarm_dense_only.py` dataset and collator, then collated sample batches successfully.
- Verified the DataLoader worker path with `num_workers=2`.
- Confirmed `stats` is no longer present in the collated SARM batch.